### PR TITLE
Fix/#32861

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,30 @@
+name: PHPUnit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  phpunit:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest ]
+        php: [ 8.3, 8.2 ]
+        stability: [ prefer-stable ]
+    name: PHPUnit - PHP ${{ matrix.php }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - name: Composer install
+        run: composer install --no-interaction --no-ansi --no-progress
+      - name: Run PHPUnit
+        run: php ./vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor
 .idea
 .phpunit.result.cache
+.phpunit.cache
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "php": ">=8.2",
     "guzzlehttp/guzzle": "~7.4",
     "ext-json": "*",
-    "ext-mbstring": "*"
+    "ext-mbstring": "*",
+    "psr/log": "^3.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^2.1.36",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "type": "library",
   "scripts": {
-    "phpstan": "php ./vendor/bin/phpstan analyse --memory-limit=4G"
+    "phpstan": "php ./vendor/bin/phpstan analyse --memory-limit=4G",
+    "test": "php ./vendor/bin/phpunit"
   },
   "require": {
     "php": ">=8.2",
@@ -14,8 +15,10 @@
     "psr/log": "^3.0"
   },
   "require-dev": {
+    "phpunit/phpunit": "^11.5",
     "phpstan/phpstan": "^2.1.36",
-    "phpstan/extension-installer": "^1.3"
+    "phpstan/extension-installer": "^1.3",
+    "phpstan/phpstan-phpunit": "^2.0.12"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnRisky="true"
+         beStrictAboutOutputDuringTests="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/ConfluencePageContentDownloader.php
+++ b/src/ConfluencePageContentDownloader.php
@@ -10,6 +10,8 @@ use Artemeon\Confluence\Endpoint\Dto\ConfluencePage;
 use Artemeon\Confluence\MacroReplacer\MacroReplacerInterface;
 use DOMDocument;
 use Exception;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class ConfluencePageContentDownloader
 {
@@ -19,15 +21,17 @@ class ConfluencePageContentDownloader
     private array $macroReplacers;
     private Content $contentEndpoint;
     private Download $downloadEndpoint;
+    private LoggerInterface $logger;
 
     /**
      * @param MacroReplacerInterface[] $macroReplacers
      */
-    public function __construct(Content $contentEndpoint, Download $downloadEndpoint, array $macroReplacers = [])
+    public function __construct(Content $contentEndpoint, Download $downloadEndpoint, array $macroReplacers = [], ?LoggerInterface $logger = null)
     {
         $this->macroReplacers = $macroReplacers;
         $this->contentEndpoint = $contentEndpoint;
         $this->downloadEndpoint = $downloadEndpoint;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function downloadPageContent(ConfluencePage $page, bool $withAttachments = true): void
@@ -54,10 +58,13 @@ class ConfluencePageContentDownloader
 
             $attachments = $this->contentEndpoint->findChildAttachments($pageId);
             foreach ($attachments as $attachment) {
-                $this->downloadEndpoint->downloadAttachment($attachment);
+                $this->downloadEndpoint->downloadAttachment($attachment, $pageId);
             }
         } catch (Exception $e) {
-            echo 'An error has occurred: ' . $e->getMessage();
+            $this->logger->error(
+                sprintf('Failed to download Confluence page content for page "%s": %s', $page->getId() ?? 'unknown', $e->getMessage()),
+                ['exception' => $e],
+            );
         }
     }
 

--- a/src/Endpoint/Content.php
+++ b/src/Endpoint/Content.php
@@ -28,6 +28,7 @@ class Content
      * @param  int|null  $offset
      * @return ConfluencePage[]
      * @throws GuzzleException
+     * @throws Exception
      */
     public function findPagesInSpace(string $spaceKey, int $limit = 2000, ?int $offset = null): array
     {
@@ -66,6 +67,9 @@ class Content
 
     /**
      * Use the Confluence Content API to retrieve page content
+     *
+     * @throws GuzzleException
+     * @throws Exception
      */
     public function findPageContent(string $pageId): ConfluencePage
     {
@@ -91,6 +95,8 @@ class Content
      * Use descendants.attachment in the Content API to get attachments
      *
      * @return list<ConfluenceAttachment>
+     * @throws GuzzleException
+     * @throws Exception
      */
     public function findChildAttachments(string $pageId): array
     {

--- a/src/Endpoint/Content.php
+++ b/src/Endpoint/Content.php
@@ -104,7 +104,7 @@ class Content
         );
 
         if ($response->getStatusCode() !== 200) {
-            throw new Exception('Fehler beim Abrufen der Attachments. HTTP-Statuscode: ' . $response->getStatusCode());
+            throw new Exception('Error retrieving attachments. HTTP status code: ' . $response->getStatusCode());
         }
 
         $attachmentsData = json_decode($response->getBody()->getContents(), true);

--- a/src/Endpoint/Content.php
+++ b/src/Endpoint/Content.php
@@ -66,10 +66,13 @@ class Content
     }
 
     /**
-     * Use the Confluence Content API to retrieve page content
+     * Fetches a single page by its ID from the Confluence Content API, expanding its
+     * stored body, version, space and labels into a {@see ConfluencePage}.
      *
-     * @throws GuzzleException
-     * @throws Exception
+     * @param string $pageId the Confluence content ID of the page to load
+     *
+     * @throws GuzzleException if the HTTP request fails (network error, timeout, …)
+     * @throws Exception if Confluence responds with a non-200 status code
      */
     public function findPageContent(string $pageId): ConfluencePage
     {
@@ -92,11 +95,15 @@ class Content
     }
 
     /**
-     * Use descendants.attachment in the Content API to get attachments
+     * Lists the attachments of a page via the Content API's child/attachment endpoint,
+     * expanding each attachment's history so its last-updated timestamp is available.
      *
-     * @return list<ConfluenceAttachment>
-     * @throws GuzzleException
-     * @throws Exception
+     * @param string $pageId the Confluence content ID of the parent page
+     *
+     * @return list<ConfluenceAttachment> the page's attachments, empty if it has none
+     *
+     * @throws GuzzleException if the HTTP request fails (network error, timeout, …)
+     * @throws Exception if Confluence responds with a non-200 status code
      */
     public function findChildAttachments(string $pageId): array
     {

--- a/src/Endpoint/Download.php
+++ b/src/Endpoint/Download.php
@@ -43,10 +43,12 @@ class Download
         $this->ensureDownloadFolder();
 
         if ($this->shouldAttachmentBeUpdated($attachment)) {
-            // Download via the supported REST endpoint; the legacy /wiki/download servlet
-            // no longer accepts API-token authentication (returns HTTP 401).
+            // Download via the supported REST endpoint. Same Basic-auth credentials
+            // (email + API token) as every other request; only the endpoint changed:
+            // the legacy /wiki/download servlet rejects API-token auth (HTTP 401),
+            // while the REST API accepts it.
             $attachmentContent = $this->client->get(
-                '/wiki/rest/api/content/' . $pageId . '/child/attachment/' . $attachment->getId() . '/download',
+                'wiki/rest/api/content/' . $pageId . '/child/attachment/' . $attachment->getId() . '/download',
                 array_merge([], $this->auth->getAuthenticationArray())
             )->getBody()->getContents();
 

--- a/src/Endpoint/Download.php
+++ b/src/Endpoint/Download.php
@@ -8,6 +8,7 @@ use Artemeon\Confluence\Endpoint\Dto\ConfluenceAttachment;
 use Artemeon\Confluence\Endpoint\Dto\ConfluencePage;
 use DateTime;
 use GuzzleHttp\Client;
+use RuntimeException;
 
 class Download
 {
@@ -22,39 +23,30 @@ class Download
         $this->downloadFolder = $downloadFolder;
     }
 
-    private function checkDownloadFolder(): bool
+    private function ensureDownloadFolder(): void
     {
-        if (!is_dir($this->downloadFolder)) {
-            return mkdir($this->downloadFolder, 0755, true);
+        if (!is_dir($this->downloadFolder) && !mkdir($this->downloadFolder, 0755, true) && !is_dir($this->downloadFolder)) {
+            throw new RuntimeException(sprintf('The download folder "%s" does not exist and could not be created.', $this->downloadFolder));
         }
-
-        return true;
     }
 
     public function downloadPageContent(ConfluencePage $confluencePage, string $fileName): void
     {
-        if (!$this->checkDownloadFolder()) {
-            echo 'Error: The download folder does not exist or could not be created.';
-
-            return;
-        }
+        $this->ensureDownloadFolder();
 
         $htmlFile = $this->downloadFolder . '/' . $fileName;
         file_put_contents($htmlFile, $confluencePage->getContent());
     }
 
-    public function downloadAttachment(ConfluenceAttachment $attachment): void
+    public function downloadAttachment(ConfluenceAttachment $attachment, string $pageId): void
     {
-        if (!$this->checkDownloadFolder()) {
-            echo 'Error: The download folder does not exist or could not be created.';
-
-            return;
-        }
+        $this->ensureDownloadFolder();
 
         if ($this->shouldAttachmentBeUpdated($attachment)) {
-            // Verwende den relativen Pfad aus der API, um das Attachment herunterzuladen
+            // Download via the supported REST endpoint; the legacy /wiki/download servlet
+            // no longer accepts API-token authentication (returns HTTP 401).
             $attachmentContent = $this->client->get(
-                '/wiki/' . $attachment->findDownloadPath(),
+                '/wiki/rest/api/content/' . $pageId . '/child/attachment/' . $attachment->getId() . '/download',
                 array_merge([], $this->auth->getAuthenticationArray())
             )->getBody()->getContents();
 

--- a/src/Endpoint/Download.php
+++ b/src/Endpoint/Download.php
@@ -8,6 +8,7 @@ use Artemeon\Confluence\Endpoint\Dto\ConfluenceAttachment;
 use Artemeon\Confluence\Endpoint\Dto\ConfluencePage;
 use DateTime;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use RuntimeException;
 
 class Download
@@ -23,6 +24,11 @@ class Download
         $this->downloadFolder = $downloadFolder;
     }
 
+    /**
+     * Makes sure the configured download folder exists, creating it recursively if needed.
+     *
+     * @throws RuntimeException if the folder is missing and cannot be created
+     */
     private function ensureDownloadFolder(): void
     {
         if (!is_dir($this->downloadFolder) && !mkdir($this->downloadFolder, 0755, true) && !is_dir($this->downloadFolder)) {
@@ -30,6 +36,14 @@ class Download
         }
     }
 
+    /**
+     * Writes a page's (already prepared) HTML content to a file in the download folder.
+     *
+     * @param ConfluencePage $confluencePage the page whose content is written
+     * @param string $fileName the target file name, relative to the download folder (e.g. "content.html")
+     *
+     * @throws RuntimeException if the download folder cannot be ensured
+     */
     public function downloadPageContent(ConfluencePage $confluencePage, string $fileName): void
     {
         $this->ensureDownloadFolder();
@@ -38,6 +52,16 @@ class Download
         file_put_contents($htmlFile, $confluencePage->getContent());
     }
 
+    /**
+     * Downloads a single page attachment into the download folder, but only if it is
+     * new or has been updated since the locally stored copy (see {@see shouldAttachmentBeUpdated()}).
+     *
+     * @param ConfluenceAttachment $attachment the attachment to download; its title is used as the file name
+     * @param string $pageId the Confluence content ID of the page the attachment belongs to
+     *
+     * @throws RuntimeException if the download folder cannot be ensured
+     * @throws GuzzleException if the HTTP request to the REST endpoint fails
+     */
     public function downloadAttachment(ConfluenceAttachment $attachment, string $pageId): void
     {
         $this->ensureDownloadFolder();
@@ -61,6 +85,17 @@ class Download
         return $this->downloadFolder . '/' . $attachment->getTitle();
     }
 
+    /**
+     * Decides whether an attachment needs to be (re-)downloaded.
+     *
+     * Returns true when no local copy exists yet, when the attachment has no known
+     * last-updated date, or when the local file is older than the attachment's
+     * last-updated date; otherwise the local copy is considered up to date.
+     *
+     * @param ConfluenceAttachment $attachment the attachment to check against its local copy
+     *
+     * @return bool true if the attachment should be downloaded, false if the local copy is current
+     */
     private function shouldAttachmentBeUpdated(ConfluenceAttachment $attachment): bool
     {
         $filepath = $this->getAttachmentFilePath($attachment);
@@ -71,9 +106,9 @@ class Download
         }
 
         if (file_exists($filepath)) {
-            $filemtime = filemtime($filepath);
-            if (is_int($filemtime)) {
-                return $filemtime < $lastUpdated->getTimestamp();
+            $fileModificationTime = filemtime($filepath);
+            if (is_int($fileModificationTime)) {
+                return $fileModificationTime < $lastUpdated->getTimestamp();
             }
         }
 

--- a/src/Endpoint/Dto/ConfluenceAttachment.php
+++ b/src/Endpoint/Dto/ConfluenceAttachment.php
@@ -34,11 +34,6 @@ class ConfluenceAttachment
         return $this->rawData['id'];
     }
 
-    public function findDownloadPath(): ?string
-    {
-        return $this->rawData['_links']['download'] ?? null;
-    }
-
     public function getTitle(): string
     {
         return $this->title;

--- a/src/Endpoint/Dto/ConfluenceAttachment.php
+++ b/src/Endpoint/Dto/ConfluenceAttachment.php
@@ -14,6 +14,7 @@ class ConfluenceAttachment
 
     /**
      * @param array{
+     *     id: string,
      *     title: string,
      *     history?: array{
      *         lastUpdated?: array{
@@ -26,6 +27,11 @@ class ConfluenceAttachment
     {
         $this->title = $rawData['title'];
         $this->lastUpdated = isset($rawData['history']['lastUpdated']['when']) ? new DateTime($rawData['history']['lastUpdated']['when']) : null;
+    }
+
+    public function getId(): string
+    {
+        return $this->rawData['id'];
     }
 
     public function findDownloadPath(): ?string

--- a/tests/ConfluencePageContentDownloaderTest.php
+++ b/tests/ConfluencePageContentDownloaderTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artemeon\Confluence\Tests;
+
+use Artemeon\Confluence\ConfluencePageContentDownloader;
+use Artemeon\Confluence\Endpoint\Content;
+use Artemeon\Confluence\Endpoint\Download;
+use Artemeon\Confluence\Endpoint\Dto\ConfluenceAttachment;
+use Artemeon\Confluence\Endpoint\Dto\ConfluencePage;
+use Artemeon\Confluence\MacroReplacer\MacroReplacerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * The downloader orchestrates macro replacement, page download and attachment download.
+ * Since the #32861 fix it must also report failures through the injected PSR-3 logger
+ * instead of silently swallowing them.
+ */
+final class ConfluencePageContentDownloaderTest extends TestCase
+{
+    public function testAppliesReplacersAndDownloadsContentAndAttachments(): void
+    {
+        $attachment = new ConfluenceAttachment(['id' => 'att1', 'title' => 'image.png']);
+
+        $replacer = $this->createMock(MacroReplacerInterface::class);
+        $replacer->expects($this->once())->method('replace')->willReturn('<p>replaced</p>');
+
+        $content = $this->createMock(Content::class);
+        $content->expects($this->once())->method('findChildAttachments')->with('123')->willReturn([$attachment]);
+
+        $download = $this->createMock(Download::class);
+        $download->expects($this->once())->method('downloadPageContent')
+            ->with($this->isInstanceOf(ConfluencePage::class), 'content.html');
+        $download->expects($this->once())->method('downloadAttachment')->with($attachment, '123');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $downloader = new ConfluencePageContentDownloader($content, $download, [$replacer], $logger);
+        $downloader->downloadPageContent($this->page('123'));
+    }
+
+    public function testDoesNotDownloadAttachmentsWhenDisabled(): void
+    {
+        $content = $this->createMock(Content::class);
+        $content->expects($this->never())->method('findChildAttachments');
+
+        $download = $this->createMock(Download::class);
+        $download->expects($this->once())->method('downloadPageContent');
+        $download->expects($this->never())->method('downloadAttachment');
+
+        $downloader = new ConfluencePageContentDownloader($content, $download);
+        $downloader->downloadPageContent($this->page('123'), false);
+    }
+
+    public function testDoesNotDownloadAttachmentsWhenPageHasNoId(): void
+    {
+        $content = $this->createMock(Content::class);
+        $content->expects($this->never())->method('findChildAttachments');
+
+        $download = $this->createMock(Download::class);
+        $download->expects($this->once())->method('downloadPageContent');
+        $download->expects($this->never())->method('downloadAttachment');
+
+        $downloader = new ConfluencePageContentDownloader($content, $download);
+        $downloader->downloadPageContent($this->page(null));
+    }
+
+    public function testLogsAnErrorWhenDownloadingFails(): void
+    {
+        // Stubs (no expectations): they only provide behaviour. The assertion lives on
+        // the logger mock below.
+        $download = self::createStub(Download::class);
+        $download->method('downloadPageContent')->willThrowException(new RuntimeException('boom'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error')
+            ->with($this->stringContains('boom'), $this->arrayHasKey('exception'));
+
+        $downloader = new ConfluencePageContentDownloader(self::createStub(Content::class), $download, [], $logger);
+
+        // Must not bubble up — the failure is caught and logged.
+        $downloader->downloadPageContent($this->page('123'));
+    }
+
+    private function page(?string $id): ConfluencePage
+    {
+        $rawData = ['body' => ['storage' => ['value' => '<p>original</p>']]];
+        if ($id !== null) {
+            $rawData['id'] = $id;
+        }
+
+        return new ConfluencePage($rawData);
+    }
+}

--- a/tests/Endpoint/ContentTest.php
+++ b/tests/Endpoint/ContentTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artemeon\Confluence\Tests\Endpoint;
+
+use Artemeon\Confluence\Endpoint\Auth;
+use Artemeon\Confluence\Endpoint\Content;
+use Artemeon\Confluence\Endpoint\Dto\ConfluenceAttachment;
+use Artemeon\Confluence\Endpoint\Dto\ConfluencePage;
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The content endpoint parses Confluence JSON responses into DTOs and fails loudly on
+ * unexpected HTTP statuses. Responses are served by a Guzzle MockHandler — no live API.
+ */
+final class ContentTest extends TestCase
+{
+    public function testFindChildAttachmentsParsesResultsIntoDtos(): void
+    {
+        $json = json_encode([
+            'results' => [
+                ['id' => 'a1', 'title' => 'first.png'],
+                ['id' => 'a2', 'title' => 'second.png', 'history' => ['lastUpdated' => ['when' => '2021-01-01T00:00:00.000Z']]],
+            ],
+        ], JSON_THROW_ON_ERROR);
+        $content = $this->content(new Response(200, [], $json));
+
+        $attachments = $content->findChildAttachments('123');
+
+        self::assertCount(2, $attachments);
+        self::assertContainsOnlyInstancesOf(ConfluenceAttachment::class, $attachments);
+        self::assertSame('a1', $attachments[0]->getId());
+        self::assertSame('second.png', $attachments[1]->getTitle());
+    }
+
+    public function testFindChildAttachmentsReturnsEmptyListWhenThereAreNoAttachments(): void
+    {
+        $content = $this->content(new Response(200, [], json_encode(['results' => []], JSON_THROW_ON_ERROR)));
+
+        self::assertSame([], $content->findChildAttachments('123'));
+    }
+
+    public function testFindChildAttachmentsThrowsOnUnexpectedSuccessStatus(): void
+    {
+        // 204 is a 2xx (so Guzzle's http_errors does not trigger) but not the 200 the
+        // endpoint requires, exercising the explicit non-200 guard.
+        $content = $this->content(new Response(204));
+
+        $this->expectException(Exception::class);
+        $content->findChildAttachments('123');
+    }
+
+    public function testFindChildAttachmentsSurfacesServerErrorsAsGuzzleException(): void
+    {
+        $content = $this->content(new Response(500, [], 'boom'));
+
+        $this->expectException(GuzzleException::class);
+        $content->findChildAttachments('123');
+    }
+
+    public function testFindPagesInSpaceParsesPagesAndTerminatesOnAShortPage(): void
+    {
+        $json = json_encode([
+            'results' => [
+                ['id' => 'p1', 'title' => 'Page one'],
+                ['id' => 'p2', 'title' => 'Page two'],
+            ],
+            'limit' => 200,
+            'size' => 2,
+        ], JSON_THROW_ON_ERROR);
+        $content = $this->content(new Response(200, [], $json));
+
+        $pages = $content->findPagesInSpace('SPACE');
+
+        self::assertCount(2, $pages);
+        self::assertContainsOnlyInstancesOf(ConfluencePage::class, $pages);
+        self::assertArrayHasKey('p1', $pages);
+        self::assertSame('Page two', $pages['p2']->getTitle());
+    }
+
+    public function testFindPageContentParsesASinglePage(): void
+    {
+        $json = json_encode([
+            'id' => 'p9',
+            'title' => 'Single page',
+            'body' => ['storage' => ['value' => '<p>body</p>']],
+        ], JSON_THROW_ON_ERROR);
+        $content = $this->content(new Response(200, [], $json));
+
+        $page = $content->findPageContent('p9');
+
+        self::assertSame('p9', $page->getId());
+        self::assertSame('<p>body</p>', $page->getContent());
+    }
+
+    public function testFindPageContentThrowsOnUnexpectedSuccessStatus(): void
+    {
+        $content = $this->content(new Response(204));
+
+        $this->expectException(Exception::class);
+        $content->findPageContent('p9');
+    }
+
+    private function content(Response $response): Content
+    {
+        $stack = HandlerStack::create(new MockHandler([$response]));
+        $client = new Client(['handler' => $stack, 'base_uri' => 'https://example.atlassian.net/']);
+
+        return new Content($client, new Auth('user@example.com', 'secret-token'));
+    }
+}

--- a/tests/Endpoint/DownloadTest.php
+++ b/tests/Endpoint/DownloadTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artemeon\Confluence\Tests\Endpoint;
+
+use Artemeon\Confluence\Endpoint\Auth;
+use Artemeon\Confluence\Endpoint\Download;
+use Artemeon\Confluence\Endpoint\Dto\ConfluenceAttachment;
+use Artemeon\Confluence\Endpoint\Dto\ConfluencePage;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * The download endpoint is the heart of the #32861 fix: attachments must be fetched
+ * from the REST API (not the legacy /wiki/download servlet) using the same Basic auth,
+ * and only when the local copy is stale. All HTTP is served by a Guzzle MockHandler,
+ * so these tests never touch the live Confluence API.
+ */
+final class DownloadTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/confluence-download-test-' . uniqid('', true);
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursively($this->tempDir);
+    }
+
+    public function testDownloadAttachmentHitsTheRestEndpointAndWritesTheFile(): void
+    {
+        $mock = new MockHandler([new Response(200, [], 'PNG-BYTES')]);
+        $download = new Download($this->client($mock), $this->auth(), $this->tempDir);
+
+        $download->downloadAttachment($this->attachment('att42', 'image.png'), '12345');
+
+        self::assertSame('PNG-BYTES', file_get_contents($this->tempDir . '/image.png'));
+        $request = $mock->getLastRequest();
+        self::assertNotNull($request);
+        self::assertSame(
+            '/wiki/rest/api/content/12345/child/attachment/att42/download',
+            $request->getUri()->getPath(),
+        );
+    }
+
+    public function testDownloadAttachmentSendsBasicAuthCredentials(): void
+    {
+        $mock = new MockHandler([new Response(200, [], 'data')]);
+        $download = new Download($this->client($mock), $this->auth(), $this->tempDir);
+
+        $download->downloadAttachment($this->attachment('att1', 'file.bin'), '1');
+
+        $request = $mock->getLastRequest();
+        self::assertNotNull($request);
+        $authorization = $request->getHeaderLine('Authorization');
+        self::assertStringStartsWith('Basic ', $authorization);
+        self::assertSame(
+            'user@example.com:secret-token',
+            base64_decode(substr($authorization, strlen('Basic ')), true),
+        );
+    }
+
+    public function testDownloadAttachmentSkipsDownloadWhenLocalCopyIsUpToDate(): void
+    {
+        file_put_contents($this->tempDir . '/image.png', 'existing');
+
+        // No responses queued: any HTTP call would make the MockHandler throw.
+        $mock = new MockHandler([]);
+        $download = new Download($this->client($mock), $this->auth(), $this->tempDir);
+
+        // Attachment last changed in the past, local file's mtime is "now" -> up to date.
+        $download->downloadAttachment($this->attachment('att1', 'image.png', '2000-01-01T00:00:00.000Z'), '1');
+
+        self::assertNull($mock->getLastRequest());
+        self::assertSame('existing', file_get_contents($this->tempDir . '/image.png'));
+    }
+
+    public function testDownloadAttachmentReDownloadsWhenRemoteIsNewerThanLocalCopy(): void
+    {
+        file_put_contents($this->tempDir . '/image.png', 'stale');
+
+        $mock = new MockHandler([new Response(200, [], 'fresh')]);
+        $download = new Download($this->client($mock), $this->auth(), $this->tempDir);
+
+        // Attachment last changed far in the future, local file's mtime is "now" -> stale.
+        $download->downloadAttachment($this->attachment('att1', 'image.png', '2999-01-01T00:00:00.000Z'), '1');
+
+        self::assertNotNull($mock->getLastRequest());
+        self::assertSame('fresh', file_get_contents($this->tempDir . '/image.png'));
+    }
+
+    public function testDownloadPageContentWritesContentToTheGivenFile(): void
+    {
+        $mock = new MockHandler([]);
+        $download = new Download($this->client($mock), $this->auth(), $this->tempDir);
+
+        $download->downloadPageContent($this->page('<h1>Hello</h1>'), 'content.html');
+
+        self::assertSame('<h1>Hello</h1>', file_get_contents($this->tempDir . '/content.html'));
+        self::assertNull($mock->getLastRequest());
+    }
+
+    public function testEnsureDownloadFolderCreatesAMissingNestedFolder(): void
+    {
+        $nested = $this->tempDir . '/a/b/c';
+        $download = new Download($this->client(new MockHandler([])), $this->auth(), $nested);
+
+        $download->downloadPageContent($this->page('x'), 'content.html');
+
+        self::assertDirectoryExists($nested);
+        self::assertFileExists($nested . '/content.html');
+    }
+
+    public function testThrowsWhenDownloadFolderCannotBeCreated(): void
+    {
+        // A file blocks the folder path, so mkdir() cannot create it.
+        $blocker = $this->tempDir . '/iam-a-file';
+        file_put_contents($blocker, 'x');
+
+        $download = new Download($this->client(new MockHandler([])), $this->auth(), $blocker . '/sub');
+
+        // Swallow the expected mkdir() warning so PHPUnit's strict handler does not
+        // fail the test before the RuntimeException we actually want to assert.
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $download->downloadPageContent($this->page('x'), 'content.html');
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    private function client(MockHandler $mock): Client
+    {
+        return new Client([
+            'handler' => HandlerStack::create($mock),
+            'base_uri' => 'https://example.atlassian.net/',
+        ]);
+    }
+
+    private function auth(): Auth
+    {
+        return new Auth('user@example.com', 'secret-token');
+    }
+
+    private function attachment(string $id, string $title, ?string $lastUpdated = null): ConfluenceAttachment
+    {
+        $rawData = ['id' => $id, 'title' => $title];
+        if ($lastUpdated !== null) {
+            $rawData['history'] = ['lastUpdated' => ['when' => $lastUpdated]];
+        }
+
+        return new ConfluenceAttachment($rawData);
+    }
+
+    private function page(string $content): ConfluencePage
+    {
+        return new ConfluencePage(['id' => '1', 'body' => ['storage' => ['value' => $content]]]);
+    }
+
+    private function removeRecursively(string $path): void
+    {
+        if (!file_exists($path)) {
+            return;
+        }
+
+        if (is_dir($path)) {
+            foreach (scandir($path) ?: [] as $entry) {
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->removeRecursively($path . '/' . $entry);
+                }
+            }
+            rmdir($path);
+
+            return;
+        }
+
+        unlink($path);
+    }
+}

--- a/tests/Endpoint/Dto/ConfluenceAttachmentTest.php
+++ b/tests/Endpoint/Dto/ConfluenceAttachmentTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artemeon\Confluence\Tests\Endpoint\Dto;
+
+use Artemeon\Confluence\Endpoint\Dto\ConfluenceAttachment;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+final class ConfluenceAttachmentTest extends TestCase
+{
+    public function testExposesIdAndTitleFromRawData(): void
+    {
+        $attachment = new ConfluenceAttachment(['id' => 'att123', 'title' => 'diagram.png']);
+
+        self::assertSame('att123', $attachment->getId());
+        self::assertSame('diagram.png', $attachment->getTitle());
+    }
+
+    public function testLastUpdatedIsNullWhenHistoryIsMissing(): void
+    {
+        $attachment = new ConfluenceAttachment(['id' => 'att123', 'title' => 'diagram.png']);
+
+        self::assertNull($attachment->getLastUpdated());
+    }
+
+    public function testLastUpdatedIsParsedFromHistoryWhenPresent(): void
+    {
+        $attachment = new ConfluenceAttachment([
+            'id' => 'att123',
+            'title' => 'diagram.png',
+            'history' => ['lastUpdated' => ['when' => '2021-06-15T10:30:00.000Z']],
+        ]);
+
+        $lastUpdated = $attachment->getLastUpdated();
+
+        self::assertInstanceOf(DateTime::class, $lastUpdated);
+        self::assertSame('2021-06-15', $lastUpdated->format('Y-m-d'));
+    }
+}


### PR DESCRIPTION
# #32861 — Fix Confluence-Attachment-Download (REST-Endpoint) + Tests & CI

  ## Problem
  Attachments (z. B. die „Schnellhilfe"-Bilder) wurden nicht mehr heruntergeladen und
  erschienen in der synchronisierten Dokumentation als 404. Ursache: Das Paket hat Attachments
  über das Legacy-Servlet `/wiki/download` geladen, das **API-Token-Authentifizierung nicht mehr
  akzeptiert und HTTP 401 zurückgibt**. Da der Fehler verschluckt wurde (ein bloßes `echo` +
  `return`), wirkte der Sync erfolgreich, während jedes Attachment still übersprungen wurde.

  ## Fix
  Attachments werden stattdessen über den unterstützten REST-Endpoint geladen:

  /wiki/rest/api/content/{pageId}/child/attachment/{attachmentId}/download

  - **Die Authentifizierung bleibt unverändert** — es werden dieselben Basic-Auth-Credentials
    (E-Mail + API-Token) gesendet wie bei jedem anderen Aufruf; nur der Endpoint wurde auf die
    REST-API umgestellt.
  - `downloadAttachment()` erhält jetzt die `pageId`, und `ConfluenceAttachment::getId()` wurde
    ergänzt, um die REST-URL zu bauen.

  ## Fehlerbehandlung (keine stillen Fehlschläge mehr)
  - `ensureDownloadFolder()` wirft jetzt eine `RuntimeException`, wenn der Download-Ordner nicht
    angelegt werden kann, statt auf stdout auszugeben und weiterzulaufen.
  - `ConfluencePageContentDownloader` fängt Exceptions und meldet sie über einen injizierten
    PSR-3-`LoggerInterface` (Default: `NullLogger`, das Verhalten bleibt also unverändert, wenn
    kein Logger übergeben wird). Fügt eine `psr/log`-Abhängigkeit hinzu.

  ## Cleanup / Aufräumen
  - Das nun tote `ConfluenceAttachment::findDownloadPath()` entfernt (einziger Nutzer des kaputten
    Legacy-Pfads), damit der 401-anfällige Pfad nicht versehentlich wiederverwendet werden kann.
  - Die Attachment-Download-URL auf einen relativen Pfad normalisiert (kein führender Slash),
    konsistent mit den übrigen Content-API-Aufrufen.
  - Die eine verbliebene deutsche Exception-Message ins Englische übersetzt (konsistent mit den
    anderen).
  - Doc-Blocks und `@throws`-Annotationen an den `Content`- und `Download`-Methoden ergänzt/erweitert
    und eine lokale Variable `$filemtime` → `$fileModificationTime` umbenannt.

  ## Tests & CI
  - **21 Unit-Tests** hinzugefügt, die den Fix abdecken: die REST-Attachment-URL, den Basic-Auth-Header,
    die Skip-/Re-Download-Entscheidung (Datei-mtime vs. Attachment-`lastUpdated`), das Anlegen des
    Download-Ordners und die neue `RuntimeException`, das JSON→DTO-Parsing, die Non-200-/5xx-Behandlung
    sowie den neuen Error-Logging-Pfad.
  - Sämtliches HTTP wird über Guzzles `MockHandler` bedient — **kein Test ruft jemals die Live-
    Confluence-API auf**, Builds bleiben damit netzwerkfrei.
  - Die Dev-Abhängigkeiten (`phpunit/phpunit`, `phpstan/phpstan-phpunit`), eine `phpunit.xml` und ein
    `composer test`-Script wieder hinzugefügt.
  - Einen eigenständigen **PHPUnit-GitHub-Actions-Workflow** ergänzt (PHP 8.2 + 8.3, gespiegelt an der
    PHPStan-Matrix), da der geteilte Workflows-Repo keinen wiederverwendbaren phpunit-Workflow hat.
    Die Tests laufen jetzt in jedem Build.

  ## Warum PHPUnit 11 (und nicht 12)
  Wir sind bewusst auf **`phpunit/phpunit ^11.5`** geblieben statt auf dem zuvor entfernten `^12.5.6`:
  `phpunit` 12 benötigt **PHP ≥ 8.3**, der Floor dieser Library ist aber **`php: >=8.2`** und die CI
  fährt einen 8.2-Matrix-Leg. Mit phpunit 12 würde `composer install` auf PHP 8.2 fehlschlagen und den
  Build brechen. PHPUnit 11.5 unterstützt PHP 8.2–8.4 und behält damit den 8.2-Support, ohne die
  Runtime-Constraint `require.php` anzufassen (Consumer sind nicht betroffen — Dev-Abhängigkeiten
  werden nicht transitiv installiert).

  ## Verifikation
  End-to-End in einer echten AGP-Installation über einen erzwungenen Voll-Sync verifiziert: Alle
  Attachments wurden korrekt heruntergeladen, inklusive des Bildes, das zuvor 404 lieferte; Text und
  Bilder werden in der UI gerendert. PHPUnit (21 Tests) und PHPStan Level 8 (über `src` + `tests`) sind
  grün.